### PR TITLE
Fix build on java 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ tmp/i18n:
 compile: tmp/stamp/compile
 tmp/stamp/compile: $(SOURCES_DIST)
 	@/bin/echo -e "$(JAVAC_CMD)\ttmp/classes/*.class"
-	$(JAVAC) -d tmp/classes -encoding UTF-8 -classpath tmp/classes:$(CLASSPATH) -sourcepath src/java $^
+	$(JAVAC) -source 1.7 -d tmp/classes -encoding UTF-8 -classpath tmp/classes:$(CLASSPATH) -sourcepath src/java $^
 	touch $@
 
 

--- a/configure
+++ b/configure
@@ -312,6 +312,9 @@ sub check_runtime (\$$$$) {
 		chomp $version[$i];
 
 		if (!($version[$i] =~ /^\d+$/)) {
+			if ($i > 0 && $version[0] >= 9) {
+				last;
+			}
 			output "can't parse version\n";
 			$$scalarref = "";
 			return


### PR DESCRIPTION
The `equivalence` build system, and gettext, don't cope well with Java 9. I have fixed it.

This is a copy of the fix in: https://github.com/respawner/gnome-split/pull/1