### PR TITLE
Store Locality object in ListStore

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+chain_width = 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "csv",
  "dirs",
  "gdk4",
+ "gio",
  "glib",
  "gtk4",
  "iana-time-zone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "slashtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slashtime"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 chrono-tz = "0.8"
 crossterm = "0.27"
 dirs = "5.0"
+gio = "*"
 glib = "*"
 gdk = { version = "*", package = "gdk4" }
 gtk = { version = "0.7.3", package = "gtk4", features = ["v4_12"]  }

--- a/src/bin/slashtime-cli.rs
+++ b/src/bin/slashtime-cli.rs
@@ -16,7 +16,11 @@ fn main() -> Result<(), tz::TzError> {
     let mut out = std::io::stdout();
 
     for location in &locations {
-        let there = now.project(location.zone.as_ref())?;
+        let there = now.project(
+            location
+                .zone
+                .as_ref(),
+        )?;
         if location.is_zulu {
             // using the macro
             queue!(

--- a/src/bin/slashtime-gtk.rs
+++ b/src/bin/slashtime-gtk.rs
@@ -17,7 +17,9 @@ const APP_ID: &str = "org.aesiniath.Slashtime";
 
 fn main() -> glib::ExitCode {
     // Create a new application
-    let app = Application::builder().application_id(APP_ID).build();
+    let app = Application::builder()
+        .application_id(APP_ID)
+        .build();
 
     // Connect to "activate" signal of `app`
     app.connect_activate(build_ui);
@@ -177,7 +179,9 @@ fn build_ui(app: &Application) {
     let utc = TimeZoneRef::utc();
     let now = tz::DateTime::now(utc).unwrap();
 
-    let from = home.borrow().clone();
+    let from = home
+        .borrow()
+        .clone();
 
     populate_model(&model, &locations, &from, &now);
 
@@ -206,7 +210,13 @@ fn populate_model(model: &StringList, locations: &[Locality], from: &Locality, w
 
     // (re)load new entries
     for location in locations {
-        let there = when.project(location.zone.as_ref()).unwrap();
+        let there = when
+            .project(
+                location
+                    .zone
+                    .as_ref(),
+            )
+            .unwrap();
 
         let string = format_line(&location, &from, &there);
 

--- a/src/bin/slashtime-gtk.rs
+++ b/src/bin/slashtime-gtk.rs
@@ -13,6 +13,8 @@ use std::rc::Rc;
 use tz::DateTime;
 use tz::TimeZoneRef;
 
+use slashtime::object::LocalityObject;
+
 const APP_ID: &str = "org.aesiniath.Slashtime";
 
 fn main() -> glib::ExitCode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use tz::TimeZone;
 
 pub mod loading;
 
+pub mod object;
+
 // a struct storing the Place information transformed into absolute and
 // relative offsets usable when ordering and displaying times.
 #[derive(Clone, Debug)]
@@ -27,13 +29,15 @@ impl Eq for Locality {}
 
 impl PartialOrd for Locality {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.offset_zulu.partial_cmp(&other.offset_zulu)
+        self.offset_zulu
+            .partial_cmp(&other.offset_zulu)
     }
 }
 
 impl Ord for Locality {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.offset_zulu.cmp(&other.offset_zulu)
+        self.offset_zulu
+            .cmp(&other.offset_zulu)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-use tz::DateTime;
-use tz::TimeZone;
+use tz;
 
 pub mod loading;
 
@@ -9,7 +8,7 @@ pub mod object;
 // relative offsets usable when ordering and displaying times.
 #[derive(Clone, Debug)]
 pub struct Locality {
-    pub zone: TimeZone,
+    pub zone: tz::TimeZone,
     pub is_zulu: bool,
     pub is_home: bool,
     pub offset_zulu: i32,  // seconds
@@ -17,6 +16,23 @@ pub struct Locality {
     pub city_name: String,
     pub country_name: String,
     pub abbreviation: String,
+}
+
+impl Default for Locality {
+    fn default() -> Self {
+        let utc = tz::TimeZone::utc();
+
+        Locality {
+            zone: utc,
+            is_zulu: true,
+            is_home: false,
+            offset_zulu: 0,
+            offset_local: 0,
+            city_name: "Zulu".to_string(),
+            country_name: "Universal Time".to_string(),
+            abbreviation: "UTC".to_string(),
+        }
+    }
 }
 
 impl PartialEq for Locality {
@@ -44,7 +60,7 @@ impl Ord for Locality {
 // Output a single line with all the relevant information. The target is the
 // location that is being represented, and from is the location this is
 // relative to (usually the home aka where you are now).
-pub fn format_line(target: &Locality, from: &Locality, when: &DateTime) -> String {
+pub fn format_line(target: &Locality, from: &Locality, when: &tz::DateTime) -> String {
     // FIXME not current time, but at timestamp
     let offset_target = (target.zone)
         .find_current_local_time_type()
@@ -72,11 +88,11 @@ fn format_locality(location: &Locality) -> String {
     format!("{}, {}", &location.city_name, &location.country_name)
 }
 
-fn format_time(when: &DateTime) -> String {
+fn format_time(when: &tz::DateTime) -> String {
     format!("{:02}:{:02}", when.hour(), when.minute())
 }
 
-fn format_date(when: &DateTime) -> String {
+fn format_date(when: &tz::DateTime) -> String {
     format!(
         "{}, {:2} {} {}",
         format_day(when.week_day()),

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,14 +1,19 @@
-use glib::Object;
-use gtk::prelude::*;
-use gtk::subclass::prelude::*;
+use std::borrow::Borrow;
+
 use super::Locality;
+use glib;
+use gtk::subclass::prelude::*;
 
 mod imp {
+    use glib;
     use glib::subclass::prelude::*;
+    use std::cell::RefCell;
 
     // Object holding the state
     #[derive(Default)]
-    pub struct LocalityObject;
+    pub struct LocalityObject {
+        pub location: RefCell<super::Locality>,
+    }
 
     // The central trait for subclassing a GObject
     #[glib::object_subclass]
@@ -27,13 +32,18 @@ glib::wrapper! {
 }
 
 impl LocalityObject {
-    pub fn new() -> Self {
-        glib::Object::new()
+    pub fn new(location: &Locality) -> Self {
+        let object: LocalityObject = glib::Object::new();
+        let imp = imp::LocalityObject::from_obj(&object);
+        imp.location
+            .replace(location.clone());
+        object
     }
-}
 
-impl Default for LocalityObject {
-    fn default() -> Self {
-        glib::Object::new()
+    pub fn get(&self) -> super::Locality {
+        let imp = self.imp();
+        imp.location
+            .borrow()
+            .clone()
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,0 +1,39 @@
+use glib::Object;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use super::Locality;
+
+mod imp {
+    use glib::subclass::prelude::*;
+
+    // Object holding the state
+    #[derive(Default)]
+    pub struct LocalityObject;
+
+    // The central trait for subclassing a GObject
+    #[glib::object_subclass]
+    impl ObjectSubclass for LocalityObject {
+        const NAME: &'static str = "SlashtimeLocalityObject";
+        type Type = super::LocalityObject;
+        type ParentType = glib::Object;
+    }
+
+    // Trait shared by all GObjects
+    impl ObjectImpl for LocalityObject {}
+}
+
+glib::wrapper! {
+    pub struct LocalityObject(ObjectSubclass<imp::LocalityObject>);
+}
+
+impl LocalityObject {
+    pub fn new() -> Self {
+        glib::Object::new()
+    }
+}
+
+impl Default for LocalityObject {
+    fn default() -> Self {
+        glib::Object::new()
+    }
+}


### PR DESCRIPTION
Use a custom Rust-side GObject subclass wrapping our Locality object as the data members of the GIO GListStore underlying the new GTK4 GtkListView. This is _so_ much boilerplate palaver it is not funny.